### PR TITLE
issue #5: Chained Shoulds only fail when the last Should in the chain fails (quickfix)

### DIFF
--- a/PShould.Tests.ps1
+++ b/PShould.Tests.ps1
@@ -90,7 +90,7 @@ Check "-TEST" { 5 | should be 5 -test }
 Check "NOT -TEST" { 7 | should not be 8 -test }
 Throws "Invalid Comparator true" { $true | should $true }
 Throws "Invalid Comparator foo" { $true | should foo }
-Throws "$null is not a collection" { $null | should be ("Null","Blank","Empty") }
+Throws '$null is not a collection' { $null | should be ("Null","Blank","Empty") }
 Check "NULL IN" { $null | should be -in ($null, "Null","Blank","Empty") }
 Check "IN" { 'null' | should be in ($null, "Null","Blank","Empty") }
 Check "ARRAY IN" { (1, 2) | should be in (1, 2, 3) }

--- a/PShould.Tests.ps1
+++ b/PShould.Tests.ps1
@@ -113,7 +113,7 @@ Check "ORDERED DICTIONARY COUNT" {
         $o1  | Should Count 3
     }
 }
-Throws "Fail on any failing chained should" { @('a','b','c') | Should Count 2 and | Should Contain 'b' }
+Throws "FAIL ON ANY FAILING CHAINED SHOULD" { @('a','b','c') | Should Count 2 and | Should Contain 'b' }
 
 if ($failedTests -gt 0) {
     throw "FAIL: $failedTests failed tests"

--- a/PShould.Tests.ps1
+++ b/PShould.Tests.ps1
@@ -113,6 +113,7 @@ Check "ORDERED DICTIONARY COUNT" {
         $o1  | Should Count 3
     }
 }
+Throws "Fail on any failing chained should" { @('a','b','c') | Should Count 2 and | Should Contain 'b' }
 
 if ($failedTests -gt 0) {
     throw "FAIL: $failedTests failed tests"

--- a/PShould.psm1
+++ b/PShould.psm1
@@ -118,7 +118,7 @@ function Should {
 
     # we'll also need an object to store the results the assertion
     $testresult = New-Object psobject 
-    $testresult | Add-Member NoteProperty Status 'inconclusive'
+    $testresult | Add-Member NoteProperty Status 'Inconclusive'
     $testresult | Add-Member NoteProperty Assertion ''
     $testresult | Add-Member NoteProperty Stacktrace ''
     $testresult.pstypenames.Insert(0, "PShould.Testresult")
@@ -205,16 +205,19 @@ function Should {
         $shouldThrow = $false
         # generate the output for each assertion
         foreach($testresult in $grandTotal) {
-            # we always want to see the result (Passed | Failed)
-            $testresult.Status
-            # in case the -test switch is not used we also want to see exception like stacktraces per result for failures
-            if ($args[$i] -ne '-test' -and $testresult.Status -eq 'Failed') {
+            # in case the -test switch is used output to the console, but don't throw
+            if ($args[$i] -eq '-test') {
+                # we always want to see the result (Passed | Failed)
+                $testresult.Status
                 "Expected that $($testresult.Assertion)"
                 $testresult.Stacktrace
+            }
+            # if -test is not used and we have a failure, mark for throwing
+            elseif($testresult.Status -eq 'Failed'){
                 $shouldThrow = $true
             }
         }
-        # throw the exception if the -test switch is not set
+        # throw the exception if marked for throwing
         if ($shouldThrow) {
             throw
         }

--- a/PShould.psm1
+++ b/PShould.psm1
@@ -163,6 +163,15 @@ function Should {
         $result = !$result
     }
 
+    # quickfix for Issue #5 Chained assertion only fails when last Should in chain fails
+    
+        if (!$result) {
+            if ($operator) { $operator += ' ' }
+            if ($not) { $not = 'not ' } else { $not = '' }
+            throw "Expected that (actual) ($savedinput) $not$comparator $operator($value)"
+        }
+    # end of quickfix
+
     # if the should ends in 'and', then emit the input for chaining
     if ($args[$i] -eq 'and') {
         $savedinput
@@ -176,13 +185,14 @@ function Should {
             $false
         }
     }
-    else {
-        if (!$result) {
-            if ($operator) { $operator += ' ' }
-            if ($not) { $not = 'not ' } else { $not = '' }
-            throw "Expected that (actual) ($savedinput) $not$comparator $operator($value)"
-        }
-    }
+    # moved the if statement to line 168 as part of quickfix for Issue #5
+    #else {
+    #    if (!$result) {
+    #        if ($operator) { $operator += ' ' }
+    #        if ($not) { $not = 'not ' } else { $not = '' }
+    #        throw "Expected that (actual) ($savedinput) $not$comparator $operator($value)"
+    #    }
+    #}
 }
 
 <#


### PR DESCRIPTION
moved verification of result before chaining
added test Fail on any failing chained Should