### PR TITLE
Enhance Contains checks to support hashtables and quantifiers

### DIFF
--- a/PShould.Tests.ps1
+++ b/PShould.Tests.ps1
@@ -58,6 +58,10 @@ Check "ARRAY CONTAIN" { (1,2) | should contain 1 }
 Check "NOT ARRAY CONTAIN" { (1,2) | should not contain 3 }
 Check "HASHTABLE CONTAIN" { @{"a"=1;"b"=2} | should contain "b" }
 Check "NOT HASHTABLE CONTAIN" { @{"a"=1;"b"=2} | should not contain 2 }
+Check "ARRAY CONTAINALL" { (1,2,3) | should containall (1,3) }
+Check "ARRAY CONTAINNONE" { (1,2,3) | should containnone (4,5,6) }
+Check "HASHTABLE CONTAINALL" { @{"a"=1;"b"=2} | should containall ("a", "b") }
+Check "HASHTABLE CONTAINNONE" { @{"a"=1;"b"=2} | should containnone ("c", "d", "e") }
 Check "MATCH" { "hi, bob" | should match 'bob$' }
 Check "NOT MATCH" { "hi, james" | should not match 'bob$' }
 Check "BLANK" { "" | should be blank }

--- a/PShould.Tests.ps1
+++ b/PShould.Tests.ps1
@@ -15,7 +15,7 @@ function Check {
     }
     catch {
         Write-Host "FAIL: $name"
-        Write-Host $_       
+        Write-Host $_
         $script:failedTests++;
     }
 }
@@ -56,6 +56,8 @@ Check "NOT EQUAL ARRAY" { (1,2) | should not equal (3,4) }
 Check "NOT EQUAL ARRAY OF DIFFERENT LENGTHS" { (1,2,3) | should not equal (3,4) }
 Check "ARRAY CONTAIN" { (1,2) | should contain 1 }
 Check "NOT ARRAY CONTAIN" { (1,2) | should not contain 3 }
+Check "HASHTABLE CONTAIN" { @{"a"=1;"b"=2} | should contain "b" }
+Check "NOT HASHTABLE CONTAIN" { @{"a"=1;"b"=2} | should not contain 2 }
 Check "MATCH" { "hi, bob" | should match 'bob$' }
 Check "NOT MATCH" { "hi, james" | should not match 'bob$' }
 Check "BLANK" { "" | should be blank }

--- a/PShould.Tests.ps1
+++ b/PShould.Tests.ps1
@@ -59,9 +59,13 @@ Check "NOT ARRAY CONTAIN" { (1,2) | should not contain 3 }
 Check "HASHTABLE CONTAIN" { @{"a"=1;"b"=2} | should contain "b" }
 Check "NOT HASHTABLE CONTAIN" { @{"a"=1;"b"=2} | should not contain 2 }
 Check "ARRAY CONTAINALL" { (1,2,3) | should containall (1,3) }
+Check "NOT ARRAY CONTAINALL" { (1,2) | should not containall (1,3) }
 Check "ARRAY CONTAINNONE" { (1,2,3) | should containnone (4,5,6) }
+Check "NOT ARRAY CONTAINNONE" { (1,2,3) | should not containnone (3,4,5,6) }
 Check "HASHTABLE CONTAINALL" { @{"a"=1;"b"=2} | should containall ("a", "b") }
+Check "NOT HASHTABLE CONTAINALL" { @{"a"=1;"c"=3} | should not containall ("a", "b") }
 Check "HASHTABLE CONTAINNONE" { @{"a"=1;"b"=2} | should containnone ("c", "d", "e") }
+Check "NOT HASHTABLE CONTAINNONE" { @{"a"=1;"b"=2} | should not containnone ("b", "c", "d") }
 Check "MATCH" { "hi, bob" | should match 'bob$' }
 Check "NOT MATCH" { "hi, james" | should not match 'bob$' }
 Check "BLANK" { "" | should be blank }

--- a/PShould.psm1
+++ b/PShould.psm1
@@ -167,7 +167,7 @@ function Should {
     if ($args[$i] -eq 'and') {
         $savedinput
     }
-    
+
     if ($args[$i] -eq '-test') {
         # if -test is specified, then just output $true/$false
         if ($result) {
@@ -371,7 +371,7 @@ function ShouldContain {
         $Element
     )
 
-    return $Collection -contains $Element
+    return $Collection.Contains($Element)
 }
 
 <#
@@ -491,7 +491,7 @@ function ShouldThrow {
 
     Tests whether the file PShould.ps1 exists.
 .Example
-    'PShould.ps1' | Should Exist 
+    'PShould.ps1' | Should Exist
 
     Tests whether the file PShould.ps1 exists.
 .Link
@@ -536,5 +536,5 @@ function ShouldContainContent {
 }
 
 # export all of the functions so we can see help on all of them
-Export-ModuleMember Should, ShouldBe, ShouldEqual, ShouldContain, ShouldMatch, ShouldCount, 
+Export-ModuleMember Should, ShouldBe, ShouldEqual, ShouldContain, ShouldMatch, ShouldCount,
     ShouldThrow, ShouldExist, ShouldContainContent

--- a/PShould.psm1
+++ b/PShould.psm1
@@ -47,6 +47,8 @@ $comparators = @(
     'Throw',
     'Match',
     'Contain',
+    'ContainAll',
+    'ContainNone',
     'Count',
     'Exist',
     'ContainContent'
@@ -362,6 +364,10 @@ function ShouldEqualEx {
     @(a,b,c) | Should Contain 'b'
 
     Checks whether the given array contains the letter b.
+.Example
+    @{"a"=1;"b"=2} | Should Contain 'b'
+
+    Checks whether the given hashtable contains the letter b as a key.
 .Link
     Should
 #>
@@ -372,6 +378,76 @@ function ShouldContain {
     )
 
     return $Collection.Contains($Element)
+}
+
+<#
+.Synopsis
+    Tests whether a collection contains all the given elements.
+.Description
+    Tests whether a collection contains all the given elements.
+.Parameter Collection
+    The collection to test.
+.Parameter Elements
+    The expected elements.
+.Example
+    ShouldContainAll @(a,b,c) @('b','a','c')
+
+    Checks whether the given array contains all the letters b, a, and c.
+.Example
+    @{a=1;c=3;b=2} | Should ContainAll @(b,a,c)
+
+    Checks whether the given hashtable contains the letters b, a, and c as keys.
+.Link
+    Should
+#>
+function ShouldContainAll {
+    param (
+        $Collection,
+        $Elements
+    )
+
+    $result = $True
+    $Elements.GetEnumerator() | ForEach-Object {
+        If (-Not ($Collection.Contains($_))) {
+            $result = $False
+        }
+    }
+    return $result
+}
+
+<#
+.Synopsis
+    Tests whether a collection contains none of the given elements.
+.Description
+    Tests whether a collection contains none of the given elements.
+.Parameter Collection
+    The collection to test.
+.Parameter Elements
+    The elements expected to not be present.
+.Example
+    ShouldContainNone @(a,b,c) @(e,f)
+
+    Checks that the given array does not contain either of the letters e, or f.
+.Example
+    @{a=1;c=3;b=2} | Should ContainNone @(e,f,g)
+
+    Checks that the given hashtable does not contain any of the keys e, f, or g.
+.Link
+    Should
+#>
+function ShouldContainNone {
+    param (
+        $Collection,
+        $Elements
+    )
+
+    $result = $True
+    $Elements.GetEnumerator() | ForEach-Object {
+        If ($Collection.Contains($_)) {
+            $result = $False
+        }
+    }
+    return $result
 }
 
 <#
@@ -536,5 +612,5 @@ function ShouldContainContent {
 }
 
 # export all of the functions so we can see help on all of them
-Export-ModuleMember Should, ShouldBe, ShouldEqual, ShouldContain, ShouldMatch, ShouldCount,
-    ShouldThrow, ShouldExist, ShouldContainContent
+Export-ModuleMember Should, ShouldBe, ShouldEqual, ShouldContain, ShouldContainAll,
+    ShouldContainNone, ShouldMatch, ShouldCount, ShouldThrow, ShouldExist, ShouldContainContent

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Getting started:
 	(1,2) | should not contain 3
 	@{"a"=1;"b"=2} | should contain "b"
 	@{"a"=1;"b"=2} | should not contain 2
+	@{"a"=1;"b"=2} | should containall @("a","b")
+	@{"a"=1;"b"=2} | should containnone @(1, 2, "e")
 	"hi, bob" | should match 'bob$'
 	"hi, james" | should not match 'bob$'
 	"" | should be blank

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Getting started:
 	(1,2,3) | should not equal (3,4)
 	(1,2) | should contain 1
 	(1,2) | should not contain 3
+	@{"a"=1;"b"=2} | should contain "b"
+	@{"a"=1;"b"=2} | should not contain 2
 	"hi, bob" | should match 'bob$'
 	"hi, james" | should not match 'bob$'
 	"" | should be blank
@@ -48,7 +50,7 @@ Getting started:
 	{ "hi" } | should not throw
 	"hi" | should { param($value) $value -eq 'hi' }
 	@(1,2) | should { param($value) $value[0] + $value[1] -eq 3 }
-	@(2,2) | should not { param($value) $value[0] + $value[1] -eq 5 
+	@(2,2) | should not { param($value) $value[0] + $value[1] -eq 5
 	1 | should be 1 and | should be 1
 	1 | should be 1 and | should not be 2
 	@() | should count 0


### PR DESCRIPTION
Two main changes:

* ShouldContain now works with hashtables (keys only)
* Added ContainAll and ContainNone checks for arrays and hashtables (keys only)